### PR TITLE
Feat/create document type

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -24,7 +24,7 @@ export default async function AdminLayout({
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <main className="container mx-auto px-4 py-8">
+      <main className="container mx-auto px-8 py-8">
         {children}
       </main>
     </div>

--- a/src/app/admin/tipos-documentales/page.tsx
+++ b/src/app/admin/tipos-documentales/page.tsx
@@ -1,14 +1,12 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Plus, Search, FileText, Calendar, Edit, Trash2, Archive } from 'lucide-react';
+import { Plus, FileText, Edit, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
-import Link from 'next/link';
 import CreateDocumentTypeForm from '@/components/admin/CreateDocumentTypeForm';
+import DataTable, { Column, Pagination } from '@/components/ui/DataTable';
 
 interface DocumentType {
   id: string;
@@ -17,15 +15,6 @@ interface DocumentType {
   documentCount: number;
   createdAt: string;
   updatedAt: string;
-}
-
-interface Pagination {
-  total: number;
-  page: number;
-  limit: number;
-  totalPages: number;
-  hasNext: boolean;
-  hasPrev: boolean;
 }
 
 interface DocumentTypesResponse {
@@ -37,7 +26,7 @@ export default function TiposDocumentalesPage() {
   const [documentTypes, setDocumentTypes] = useState<DocumentType[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
-  const [sortBy, setSortBy] = useState<'name' | 'createdAt' | 'documentCount'>('name');
+  const [sortBy, setSortBy] = useState('name');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
   const [showCreateForm, setShowCreateForm] = useState(false);
@@ -49,6 +38,49 @@ export default function TiposDocumentalesPage() {
     hasNext: false,
     hasPrev: false
   });
+
+  const columns: Column<DocumentType>[] = [
+    {
+      key: 'name',
+      label: 'Tipo Documental',
+      sortable: true,
+      className: '1fr',
+      render: (item) => (
+        <div>
+          <div className="font-medium text-gray-900 dark:text-white">
+            {item.name}
+          </div>
+          {item.description && (
+            <div className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+              {item.description}
+            </div>
+          )}
+        </div>
+      )
+    },
+    {
+      key: 'createdAt',
+      label: 'Fecha de creación',
+      sortable: true,
+      className: '200px',
+      render: (item) => (
+        <div className="text-sm text-gray-600 dark:text-gray-400">
+          {new Date(item.createdAt).toLocaleDateString()}
+        </div>
+      )
+    },
+    {
+      key: 'documentCount',
+      label: 'Cantidad de documentos',
+      sortable: true,
+      className: '200px',
+      render: (item) => (
+        <Badge variant="secondary" className="font-mono">
+          {item.documentCount} {item.documentCount === 1 ? 'Documento' : 'Documentos'}
+        </Badge>
+      )
+    }
+  ];
 
   const fetchDocumentTypes = async () => {
     try {
@@ -156,16 +188,41 @@ export default function TiposDocumentalesPage() {
     }
   };
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
-          <p className="mt-4 text-gray-600 dark:text-gray-400">Cargando tipos documentales...</p>
-        </div>
-      </div>
-    );
-  }
+  const handleSort = (key: string) => {
+    if (sortBy === key) {
+      setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortBy(key);
+      setSortOrder('asc');
+    }
+  };
+
+  const handlePageChange = (page: number) => {
+    setPagination(prev => ({ ...prev, page }));
+  };
+
+  const renderActions = (item: DocumentType) => (
+    <div className="flex items-center gap-2">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-8 w-8 p-0"
+        title="Editar"
+      >
+        <Edit className="h-4 w-4" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-8 w-8 p-0 text-red-600 hover:text-red-700 hover:bg-red-50"
+        title="Eliminar"
+        onClick={() => handleDeleteType(item.id, item.name)}
+        disabled={item.documentCount > 0}
+      >
+        <Trash2 className="h-4 w-4" />
+      </Button>
+    </div>
+  );
 
   return (
     <div className="space-y-6">
@@ -188,189 +245,30 @@ export default function TiposDocumentalesPage() {
         </Button>
       </div>
 
-      {/* Search and Filters */}
-      <Card>
-        <CardContent className="pt-6">
-          <div className="flex flex-col sm:flex-row gap-4">
-            <div className="relative flex-1">
-              <Search className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-              <Input
-                placeholder="Filtrar documentales"
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                className="pl-10"
-              />
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Document Types Table */}
-      <Card>
-        <CardContent className="p-0">
-          {documentTypes.length === 0 ? (
-            <div className="text-center py-12">
-              <FileText className="w-16 h-16 text-gray-400 mx-auto mb-4" />
-              <p className="text-xl font-medium text-gray-600 dark:text-gray-400 mb-2">
-                {searchTerm ? 'No se encontraron tipos documentales' : 'No hay tipos documentales registrados'}
-              </p>
-              {!searchTerm && (
-                <p className="text-gray-500 dark:text-gray-500">
-                  Crea el primer tipo documental para comenzar
-                </p>
-              )}
-            </div>
-          ) : (
-            <div className="overflow-hidden">
-              {/* Table Header */}
-              <div className="bg-gray-50 dark:bg-gray-800 px-6 py-3 border-b">
-                <div className="grid grid-cols-12 gap-4 items-center">
-                  <div className="col-span-1">
-                    <input
-                      type="checkbox"
-                      className="rounded border-gray-300"
-                      checked={selectedTypes.length === documentTypes.length}
-                      onChange={handleSelectAll}
-                    />
-                  </div>
-                  <div 
-                    className="col-span-4 font-medium text-gray-900 dark:text-white cursor-pointer flex items-center gap-2"
-                    onClick={() => {
-                      setSortBy('name');
-                      setSortOrder(sortBy === 'name' && sortOrder === 'asc' ? 'desc' : 'asc');
-                    }}
-                  >
-                    Tipo Documental
-                    {sortBy === 'name' && (
-                      <span className="text-xs">{sortOrder === 'asc' ? '↑' : '↓'}</span>
-                    )}
-                  </div>
-                  <div 
-                    className="col-span-3 font-medium text-gray-900 dark:text-white cursor-pointer flex items-center gap-2"
-                    onClick={() => {
-                      setSortBy('createdAt');
-                      setSortOrder(sortBy === 'createdAt' && sortOrder === 'asc' ? 'desc' : 'asc');
-                    }}
-                  >
-                    Fecha de creación
-                    {sortBy === 'createdAt' && (
-                      <span className="text-xs">{sortOrder === 'asc' ? '↑' : '↓'}</span>
-                    )}
-                  </div>
-                  <div 
-                    className="col-span-3 font-medium text-gray-900 dark:text-white cursor-pointer flex items-center gap-2"
-                    onClick={() => {
-                      setSortBy('documentCount');
-                      setSortOrder(sortBy === 'documentCount' && sortOrder === 'asc' ? 'desc' : 'asc');
-                    }}
-                  >
-                    Cantidad de documentos
-                    {sortBy === 'documentCount' && (
-                      <span className="text-xs">{sortOrder === 'asc' ? '↑' : '↓'}</span>
-                    )}
-                  </div>
-                  <div className="col-span-1 font-medium text-gray-900 dark:text-white">
-                    Acciones
-                  </div>
-                </div>
-              </div>
-
-              {/* Table Body */}
-              <div className="divide-y divide-gray-200 dark:divide-gray-700">
-                {documentTypes.map((type, index) => (
-                  <div key={type.id} className="px-6 py-4 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
-                    <div className="grid grid-cols-12 gap-4 items-center">
-                      <div className="col-span-1">
-                        <input
-                          type="checkbox"
-                          className="rounded border-gray-300"
-                          checked={selectedTypes.includes(type.id)}
-                          onChange={() => handleSelectType(type.id)}
-                        />
-                      </div>
-                      <div className="col-span-4">
-                        <div className="font-medium text-gray-900 dark:text-white">
-                          {type.name}
-                        </div>
-                        {type.description && (
-                          <div className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                            {type.description}
-                          </div>
-                        )}
-                      </div>
-                      <div className="col-span-3">
-                        <div className="text-sm text-gray-600 dark:text-gray-400">
-                          {new Date(type.createdAt).toLocaleDateString()}
-                        </div>
-                      </div>
-                      <div className="col-span-3">
-                        <Badge variant="secondary" className="font-mono">
-                          {type.documentCount} {type.documentCount === 1 ? 'documento' : 'documentos'}
-                        </Badge>
-                      </div>
-                      <div className="col-span-1">
-                        <div className="flex items-center gap-2">
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-8 w-8 p-0"
-                            title="Editar"
-                          >
-                            <Edit className="h-4 w-4" />
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-8 w-8 p-0 text-red-600 hover:text-red-700 hover:bg-red-50"
-                            title="Eliminar"
-                            onClick={() => handleDeleteType(type.id, type.name)}
-                            disabled={type.documentCount > 0}
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              {/* Table Footer */}
-              <div className="px-6 py-3 bg-gray-50 dark:bg-gray-800 border-t flex items-center justify-between">
-                <div className="text-sm text-gray-600 dark:text-gray-400">
-                  {selectedTypes.length > 0 
-                    ? `${selectedTypes.length} de ${documentTypes.length} filas seleccionadas`
-                    : `Mostrando ${(pagination.page - 1) * pagination.limit + 1}-${Math.min(pagination.page * pagination.limit, pagination.total)} de ${pagination.total} tipos documentales`
-                  }
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className="text-sm text-gray-600 dark:text-gray-400">
-                    Página {pagination.page} de {pagination.totalPages}
-                  </span>
-                  <Button 
-                    variant="ghost" 
-                    size="sm" 
-                    disabled={!pagination.hasPrev || loading}
-                    onClick={handlePrevPage}
-                    className="transition-all duration-200 hover:bg-blue-50 hover:text-blue-700 dark:hover:bg-blue-900/20 dark:hover:text-blue-300 disabled:hover:bg-transparent disabled:hover:text-current"
-                  >
-                    Anterior
-                  </Button>
-                  <Button 
-                    variant="ghost" 
-                    size="sm" 
-                    disabled={!pagination.hasNext || loading}
-                    onClick={handleNextPage}
-                    className="transition-all duration-200 hover:bg-blue-50 hover:text-blue-700 dark:hover:bg-blue-900/20 dark:hover:text-blue-300 disabled:hover:bg-transparent disabled:hover:text-current"
-                  >
-                    Siguiente
-                  </Button>
-                </div>
-              </div>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      {/* Data Table */}
+      <DataTable
+        data={documentTypes}
+        columns={columns}
+        loading={loading}
+        searchTerm={searchTerm}
+        onSearchChange={setSearchTerm}
+        searchPlaceholder="Filtrar documentales"
+        sortBy={sortBy}
+        sortOrder={sortOrder}
+        onSort={handleSort}
+        pagination={pagination}
+        onPageChange={handlePageChange}
+        selectedItems={selectedTypes}
+        onSelectAll={handleSelectAll}
+        onSelectItem={handleSelectType}
+        getItemId={(item) => item.id}
+        emptyState={{
+          icon: <FileText className="w-16 h-16 text-gray-400 mx-auto mb-4" />,
+          title: searchTerm ? 'No se encontraron tipos documentales' : 'No hay tipos documentales registrados',
+          description: !searchTerm ? 'Crea el primer tipo documental para comenzar' : undefined
+        }}
+        actions={renderActions}
+      />
 
       {/* Create Document Type Form */}
       <CreateDocumentTypeForm

--- a/src/components/admin/CreateDocumentTypeForm.tsx
+++ b/src/components/admin/CreateDocumentTypeForm.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { toast } from 'sonner';
+import { FileText } from 'lucide-react';
+import FormDialog from '@/components/ui/FormDialog';
+
+interface CreateDocumentTypeFormProps {
+  open: boolean;
+  onClose: () => void;
+  onDocumentTypeCreated: () => void;
+}
+
+export default function CreateDocumentTypeForm({ 
+  open, 
+  onClose, 
+  onDocumentTypeCreated 
+}: CreateDocumentTypeFormProps) {
+  const [loading, setLoading] = useState(false);
+  const [formData, setFormData] = useState({
+    name: '',
+    description: '',
+  });
+
+  const handleInputChange = (field: string, value: string) => {
+    setFormData(prev => ({
+      ...prev,
+      [field]: value
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!formData.name.trim()) {
+      toast.error('El nombre del tipo documental es requerido');
+      return;
+    }
+
+    try {
+      setLoading(true);
+
+      const response = await fetch('/api/admin/document-types', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: formData.name.trim(),
+          description: formData.description.trim() || null,
+        }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        toast.error(result.error || 'Error al crear tipo documental');
+        return;
+      }
+
+      // Reset form
+      setFormData({
+        name: '',
+        description: '',
+      });
+
+      onDocumentTypeCreated();
+      onClose();
+      toast.success('Tipo documental creado exitosamente');
+    } catch (error) {
+      console.error('Error creating document type:', error);
+      toast.error('Error al crear tipo documental');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!loading) {
+      setFormData({
+        name: '',
+        description: '',
+      });
+      onClose();
+    }
+  };
+
+  const canSubmit = formData.name.trim().length > 0;
+
+  return (
+    <FormDialog
+      open={open}
+      onClose={handleClose}
+      title="Crear nuevo Tipo Documental"
+      description="Completa los siguientes datos con un nombre único y no debe estar vacío."
+      onSubmit={handleSubmit}
+      loading={loading}
+      submitText="Crear Tipo"
+      canSubmit={canSubmit}
+    >
+      <div className="space-y-2">
+        <Label htmlFor="documentTypeName">Nombre de Tipo Documental *</Label>
+        <div className="relative">
+          <FileText className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+          <Input
+            id="documentTypeName"
+            type="text"
+            value={formData.name}
+            onChange={(e) => handleInputChange('name', e.target.value)}
+            placeholder="Ingresa el nombre del tipo documental"
+            className="pl-10"
+            required
+            disabled={loading}
+            maxLength={100}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="documentTypeDescription">Descripción (Opcional)</Label>
+        <Input
+          id="documentTypeDescription"
+          type="text"
+          value={formData.description}
+          onChange={(e) => handleInputChange('description', e.target.value)}
+          placeholder="Descripción del tipo documental"
+          disabled={loading}
+          maxLength={255}
+        />
+        <p className="text-xs text-gray-500">Ayuda a identificar este tipo documental</p>
+      </div>
+    </FormDialog>
+  );
+}

--- a/src/components/admin/CreateUserDialog.tsx
+++ b/src/components/admin/CreateUserDialog.tsx
@@ -1,15 +1,12 @@
 'use client';
 
 import { useState } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { authClient } from '@/lib/auth-client';
 import { getRoles } from '@/lib/roles';
 import { toast } from 'sonner';
-import { Loader2 } from 'lucide-react';
+import FormDialog from '@/components/ui/FormDialog';
 
 interface CreateUserDialogProps {
   open: boolean;
@@ -79,96 +76,93 @@ export default function CreateUserDialog({ open, onClose, onUserCreated }: Creat
     }
   };
 
+  const canSubmit = formData.name && formData.username && formData.email && formData.password && formData.role;
+
   return (
-    <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-w-md">
-        <DialogHeader>
-          <DialogTitle>Crear Nuevo Usuario</DialogTitle>
-        </DialogHeader>
-        
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="name">Nombre Completo *</Label>
-            <Input
-              id="name"
-              type="text"
-              value={formData.name}
-              onChange={(e) => handleInputChange('name', e.target.value)}
-              placeholder="Nombre completo del usuario"
-              required
-            />
-          </div>
+    <FormDialog
+      open={open}
+      onClose={onClose}
+      title="Crear Nuevo Usuario"
+      onSubmit={handleSubmit}
+      loading={loading}
+      submitText="Crear Usuario"
+      canSubmit={canSubmit}
+    >
+      <div className="space-y-2">
+        <Label htmlFor="name">Nombre Completo *</Label>
+        <Input
+          id="name"
+          type="text"
+          value={formData.name}
+          onChange={(e) => handleInputChange('name', e.target.value)}
+          placeholder="Nombre completo del usuario"
+          required
+          disabled={loading}
+        />
+      </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="username">Nombre de Usuario *</Label>
-            <Input
-              id="username"
-              type="text"
-              value={formData.username}
-              onChange={(e) => handleInputChange('username', e.target.value)}
-              placeholder="nombre.usuario"
-              required
-              minLength={5}
-              maxLength={20}
-            />
-            <p className="text-xs text-gray-600">Entre 5 y 20 caracteres</p>
-          </div>
+      <div className="space-y-2">
+        <Label htmlFor="username">Nombre de Usuario *</Label>
+        <Input
+          id="username"
+          type="text"
+          value={formData.username}
+          onChange={(e) => handleInputChange('username', e.target.value)}
+          placeholder="nombre.usuario"
+          required
+          minLength={5}
+          maxLength={20}
+          disabled={loading}
+        />
+        <p className="text-xs text-gray-600">Entre 5 y 20 caracteres</p>
+      </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="email">Correo Electrónico *</Label>
-            <Input
-              id="email"
-              type="email"
-              value={formData.email}
-              onChange={(e) => handleInputChange('email', e.target.value)}
-              placeholder="usuario@ejemplo.com"
-              required
-            />
-          </div>
+      <div className="space-y-2">
+        <Label htmlFor="email">Correo Electrónico *</Label>
+        <Input
+          id="email"
+          type="email"
+          value={formData.email}
+          onChange={(e) => handleInputChange('email', e.target.value)}
+          placeholder="usuario@ejemplo.com"
+          required
+          disabled={loading}
+        />
+      </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="password">Contraseña *</Label>
-            <Input
-              id="password"
-              type="password"
-              value={formData.password}
-              onChange={(e) => handleInputChange('password', e.target.value)}
-              placeholder="Contraseña segura"
-              required
-              minLength={6}
-            />
-            <p className="text-xs text-gray-600">Mínimo 6 caracteres</p>
-          </div>
+      <div className="space-y-2">
+        <Label htmlFor="password">Contraseña *</Label>
+        <Input
+          id="password"
+          type="password"
+          value={formData.password}
+          onChange={(e) => handleInputChange('password', e.target.value)}
+          placeholder="Contraseña segura"
+          required
+          minLength={6}
+          disabled={loading}
+        />
+        <p className="text-xs text-gray-600">Mínimo 6 caracteres</p>
+      </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="role">Rol *</Label>
-            <select
-              id="role"
-              value={formData.role}
-              onChange={(e) => handleInputChange('role', e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-              required
-            >
-              <option value="">Selecciona un rol</option>
-              {roles.map((role) => (
-                <option key={role.id} value={role.id}>
-                  {role.name}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <div className="flex justify-end gap-3 pt-4">
-            <Button type="button" variant="outline" onClick={onClose}>
-              Cancelar
-            </Button>
-            <Button type="submit" disabled={loading}>
-              {loading && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
-              Crear Usuario
-            </Button>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
+      <div className="space-y-2">
+        <Label htmlFor="role">Rol *</Label>
+        <select
+          id="role"
+          value={formData.role}
+          onChange={(e) => handleInputChange('role', e.target.value)}
+          className="w-full px-3 py-2 border-2 border-solid border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 appearance-none"
+          required
+          disabled={loading}
+        >
+          <option value="" className="text-gray-500 dark:text-gray-400">Selecciona un rol</option>
+          {roles.map((role) => (
+            <option key={role.id} value={role.id} className="text-gray-900 dark:text-white bg-white dark:bg-gray-800">
+              {role.name}
+            </option>
+          ))}
+        </select>
+      </div>
+    </FormDialog>
   );
 }

--- a/src/components/ui/DataTable.tsx
+++ b/src/components/ui/DataTable.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { ReactNode, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent } from '@/components/ui/card';
+import { Search } from 'lucide-react';
+
+export interface Column<T> {
+  key: keyof T | string;
+  label: string;
+  sortable?: boolean;
+  render?: (item: T) => ReactNode;
+  className?: string;
+}
+
+export interface Pagination {
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+  hasNext: boolean;
+  hasPrev: boolean;
+}
+
+interface DataTableProps<T> {
+  data: T[];
+  columns: Column<T>[];
+  loading?: boolean;
+  searchTerm: string;
+  onSearchChange: (value: string) => void;
+  searchPlaceholder?: string;
+  sortBy: string;
+  sortOrder: 'asc' | 'desc';
+  onSort: (key: string) => void;
+  pagination: Pagination;
+  onPageChange: (page: number) => void;
+  selectedItems: string[];
+  onSelectAll: () => void;
+  onSelectItem: (id: string) => void;
+  getItemId: (item: T) => string;
+  emptyState: {
+    icon: ReactNode;
+    title: string;
+    description?: string;
+  };
+  actions?: (item: T) => ReactNode;
+}
+
+export default function DataTable<T>({
+  data,
+  columns,
+  loading = false,
+  searchTerm,
+  onSearchChange,
+  searchPlaceholder = "Buscar...",
+  sortBy,
+  sortOrder,
+  onSort,
+  pagination,
+  onPageChange,
+  selectedItems,
+  onSelectAll,
+  onSelectItem,
+  getItemId,
+  emptyState,
+  actions
+}: DataTableProps<T>) {
+  const handleNextPage = () => {
+    if (pagination.hasNext) {
+      onPageChange(pagination.page + 1);
+    }
+  };
+
+  const handlePrevPage = () => {
+    if (pagination.hasPrev) {
+      onPageChange(pagination.page - 1);
+    }
+  };
+
+  const renderCellValue = (item: T, column: Column<T>) => {
+    if (column.render) {
+      return column.render(item);
+    }
+    
+    const value = column.key.includes('.') 
+      ? column.key.split('.').reduce((obj: any, key) => obj?.[key], item)
+      : (item as any)[column.key];
+    
+    return value;
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+          <p className="mt-4 text-gray-600 dark:text-gray-400">Cargando...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Search */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="relative">
+            <Search className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+            <Input
+              placeholder={searchPlaceholder}
+              value={searchTerm}
+              onChange={(e) => onSearchChange(e.target.value)}
+              className="pl-10"
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Table */}
+      <Card>
+        <CardContent className="p-0">
+          {data.length === 0 ? (
+            <div className="text-center py-12">
+              {emptyState.icon}
+              <p className="text-xl font-medium text-gray-600 dark:text-gray-400 mb-2">
+                {emptyState.title}
+              </p>
+              {emptyState.description && (
+                <p className="text-gray-500 dark:text-gray-500">
+                  {emptyState.description}
+                </p>
+              )}
+            </div>
+          ) : (
+            <div className="overflow-hidden">
+              {/* Table Header */}
+              <div className="bg-gray-50 dark:bg-gray-800 px-6 py-3 border-b">
+                <div className="grid gap-4 items-center" style={{ gridTemplateColumns: `auto ${columns.map(col => col.className || '1fr').join(' ')} ${actions ? 'auto' : ''}` }}>
+                  <div>
+                    <input
+                      type="checkbox"
+                      className="rounded border-gray-300"
+                      checked={selectedItems.length === data.length && data.length > 0}
+                      onChange={onSelectAll}
+                    />
+                  </div>
+                  {columns.map((column) => (
+                    <div 
+                      key={String(column.key)}
+                      className={`font-medium text-gray-900 dark:text-white ${column.sortable ? 'cursor-pointer flex items-center gap-2' : ''}`}
+                      onClick={() => column.sortable && onSort(String(column.key))}
+                    >
+                      {column.label}
+                      {column.sortable && sortBy === column.key && (
+                        <span className="text-xs">{sortOrder === 'asc' ? '↑' : '↓'}</span>
+                      )}
+                    </div>
+                  ))}
+                  {actions && (
+                    <div className="font-medium text-gray-900 dark:text-white">
+                      Acciones
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Table Body */}
+              <div className="divide-y divide-gray-200 dark:divide-gray-700">
+                {data.map((item) => {
+                  const itemId = getItemId(item);
+                  return (
+                    <div key={itemId} className="px-6 py-4 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+                      <div className="grid gap-4 items-center" style={{ gridTemplateColumns: `auto ${columns.map(col => col.className || '1fr').join(' ')} ${actions ? 'auto' : ''}` }}>
+                        <div>
+                          <input
+                            type="checkbox"
+                            className="rounded border-gray-300"
+                            checked={selectedItems.includes(itemId)}
+                            onChange={() => onSelectItem(itemId)}
+                          />
+                        </div>
+                        {columns.map((column) => (
+                          <div key={String(column.key)}>
+                            {renderCellValue(item, column)}
+                          </div>
+                        ))}
+                        {actions && (
+                          <div>
+                            {actions(item)}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Table Footer */}
+              <div className="px-6 py-3 bg-gray-50 dark:bg-gray-800 border-t flex items-center justify-between">
+                <div className="text-sm text-gray-600 dark:text-gray-400">
+                  {selectedItems.length > 0 
+                    ? `${selectedItems.length} de ${data.length} filas seleccionadas`
+                    : `Mostrando ${(pagination.page - 1) * pagination.limit + 1}-${Math.min(pagination.page * pagination.limit, pagination.total)} de ${pagination.total} elementos`
+                  }
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-gray-600 dark:text-gray-400">
+                    Página {pagination.page} de {pagination.totalPages}
+                  </span>
+                  <Button 
+                    variant="ghost" 
+                    size="sm" 
+                    disabled={!pagination.hasPrev || loading}
+                    onClick={handlePrevPage}
+                    className="transition-all duration-200 hover:bg-blue-50 hover:text-blue-700 dark:hover:bg-blue-900/20 dark:hover:text-blue-300 disabled:hover:bg-transparent disabled:hover:text-current"
+                  >
+                    Anterior
+                  </Button>
+                  <Button 
+                    variant="ghost" 
+                    size="sm" 
+                    disabled={!pagination.hasNext || loading}
+                    onClick={handleNextPage}
+                    className="transition-all duration-200 hover:bg-blue-50 hover:text-blue-700 dark:hover:bg-blue-900/20 dark:hover:text-blue-300 disabled:hover:bg-transparent disabled:hover:text-current"
+                  >
+                    Siguiente
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/ui/FormDialog.tsx
+++ b/src/components/ui/FormDialog.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Loader2 } from 'lucide-react';
+
+interface FormDialogProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  description?: string;
+  children: ReactNode;
+  onSubmit: (e: React.FormEvent) => void;
+  loading?: boolean;
+  submitText?: string;
+  cancelText?: string;
+  canSubmit?: boolean;
+}
+
+export default function FormDialog({
+  open,
+  onClose,
+  title,
+  description,
+  children,
+  onSubmit,
+  loading = false,
+  submitText = 'Guardar',
+  cancelText = 'Cancelar',
+  canSubmit = true
+}: FormDialogProps) {
+  const handleClose = () => {
+    if (!loading) {
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        
+        {description && (
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+            {description}
+          </p>
+        )}
+        
+        <form onSubmit={onSubmit} className="space-y-4">
+          {children}
+
+          <div className="flex justify-end gap-3 pt-4">
+            <Button 
+              type="button" 
+              variant="outline" 
+              onClick={handleClose}
+              disabled={loading}
+            >
+              {cancelText}
+            </Button>
+            <Button 
+              type="submit" 
+              disabled={loading || !canSubmit}
+            >
+              {loading && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+              {submitText}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
# Document Types Management & Reusable Components

## Summary
Implements document types creation and listing functionality, plus creates reusable UI components for better code organization.

## Features
- **Create Document Types**: Modal form with validation
- **List & Search**: Paginated table with search and sorting
- **Pagination**: 5 items per page with navigation
- **Reusable Components**: FormDialog and DataTable components
- **Edit/Delete**: UI prepared but functionality not yet implemented

## Components Created
- `FormDialog` - Generic form modal (used by both user and document type forms)
- `DataTable` - Reusable table with search, sort, pagination, selection
- Refactored existing forms to use new components

## API Endpoints
- `GET /api/admin/document-types` - List with pagination/search
- `POST /api/admin/document-types` - Create new type
- `PUT /api/admin/document-types/[id]` - Update endpoint ready (UI pending)
- `DELETE /api/admin/document-types/[id]` - Delete endpoint ready (UI shows buttons but not functional)

## Database
```sql
-- New tables
document_type (id, name, description, timestamps)
document (id, title, documentTypeId, createdById, timestamps)
```

## Migration Required
```bash
pnpm db:migrate
```