### PR TITLE
Feat/delete document type

### DIFF
--- a/src/app/admin/document-types/page.tsx
+++ b/src/app/admin/document-types/page.tsx
@@ -233,11 +233,7 @@ export default function TiposDocumentalesPage() {
       <Button
         variant="ghost"
         size="sm"
-        className={`h-8 w-8 p-0 transition-all duration-200 hover:scale-105 ${
-          item.documentCount > 0 
-            ? 'text-orange-500 hover:text-orange-600 hover:bg-orange-50 dark:hover:bg-orange-900/20' 
-            : 'text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20'
-        }`}
+        className="h-8 w-8 p-0 transition-all duration-200 hover:scale-105 text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20"
         title={item.documentCount > 0 ? "No se puede eliminar: tipo en uso" : "Eliminar"}
         onClick={() => handleDeleteClick(item)}
       >

--- a/src/app/admin/document-types/page.tsx
+++ b/src/app/admin/document-types/page.tsx
@@ -7,6 +7,7 @@ import { Plus, FileText, Edit, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import CreateDocumentTypeForm from '@/components/admin/CreateDocumentTypeForm';
 import DataTable, { Column, Pagination } from '@/components/ui/DataTable';
+import DeleteDialog from '@/components/ui/DeleteDialog';
 
 interface DocumentType {
   id: string;
@@ -30,6 +31,8 @@ export default function TiposDocumentalesPage() {
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
   const [showCreateForm, setShowCreateForm] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [itemToDelete, setItemToDelete] = useState<DocumentType | null>(null);
   const [pagination, setPagination] = useState<Pagination>({
     total: 0,
     page: 1,
@@ -147,13 +150,21 @@ export default function TiposDocumentalesPage() {
     );
   };
 
-  const handleDeleteType = async (typeId: string, typeName: string) => {
-    if (!confirm(`¿Estás seguro de que quieres eliminar el tipo documental "${typeName}"?`)) {
+  const handleDeleteClick = (item: DocumentType) => {
+    if (item.documentCount > 0) {
+      toast.error(`No se puede eliminar: este tipo está en uso por ${item.documentCount} ${item.documentCount === 1 ? 'documento' : 'documentos'}`);
       return;
     }
+    
+    setItemToDelete(item);
+    setShowDeleteDialog(true);
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!itemToDelete) return;
 
     try {
-      const response = await fetch(`/api/admin/document-types/${typeId}`, {
+      const response = await fetch(`/api/admin/document-types/${itemToDelete.id}`, {
         method: 'DELETE',
       });
 
@@ -165,10 +176,18 @@ export default function TiposDocumentalesPage() {
 
       toast.success('Tipo documental eliminado exitosamente');
       fetchDocumentTypes();
+      setShowDeleteDialog(false);
+      setItemToDelete(null);
     } catch (error) {
       console.error('Error deleting document type:', error);
       toast.error('Error al eliminar tipo documental');
+      throw error;
     }
+  };
+
+  const handleDeleteCancel = () => {
+    setShowDeleteDialog(false);
+    setItemToDelete(null);
   };
 
   const handleDocumentTypeCreated = () => {
@@ -206,20 +225,23 @@ export default function TiposDocumentalesPage() {
       <Button
         variant="ghost"
         size="sm"
-        className="h-8 w-8 p-0"
+        className="h-8 w-8 p-0 transition-all duration-200 hover:scale-105 hover:bg-blue-50 hover:text-blue-700 dark:hover:bg-blue-900/20 dark:hover:text-blue-300"
         title="Editar"
       >
-        <Edit className="h-4 w-4" />
+        <Edit className="h-4 w-4 transition-transform duration-200" />
       </Button>
       <Button
         variant="ghost"
         size="sm"
-        className="h-8 w-8 p-0 text-red-600 hover:text-red-700 hover:bg-red-50"
-        title="Eliminar"
-        onClick={() => handleDeleteType(item.id, item.name)}
-        disabled={item.documentCount > 0}
+        className={`h-8 w-8 p-0 transition-all duration-200 hover:scale-105 ${
+          item.documentCount > 0 
+            ? 'text-orange-500 hover:text-orange-600 hover:bg-orange-50 dark:hover:bg-orange-900/20' 
+            : 'text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20'
+        }`}
+        title={item.documentCount > 0 ? "No se puede eliminar: tipo en uso" : "Eliminar"}
+        onClick={() => handleDeleteClick(item)}
       >
-        <Trash2 className="h-4 w-4" />
+        <Trash2 className="h-4 w-4 transition-transform duration-200" />
       </Button>
     </div>
   );
@@ -275,6 +297,20 @@ export default function TiposDocumentalesPage() {
         open={showCreateForm}
         onClose={() => setShowCreateForm(false)}
         onDocumentTypeCreated={handleDocumentTypeCreated}
+      />
+
+      {/* Delete Confirmation Dialog */}
+      <DeleteDialog
+        open={showDeleteDialog}
+        onClose={handleDeleteCancel}
+        onConfirm={handleDeleteConfirm}
+        title="Eliminar Tipo Documental"
+        itemName={itemToDelete?.name}
+        disabled={itemToDelete ? itemToDelete.documentCount > 0 : false}
+        disabledReason={itemToDelete && itemToDelete.documentCount > 0 
+          ? `Este tipo está en uso por ${itemToDelete.documentCount} ${itemToDelete.documentCount === 1 ? 'documento' : 'documentos'} y no puede ser eliminado.`
+          : undefined
+        }
       />
     </div>
   );

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -181,7 +181,7 @@ export default function AdminDashboard() {
               Gestiona los tipos documentales del sistema
             </p>
             <div className="flex gap-2">
-              <Link href="/admin/tipos-documentales">
+              <Link href="/admin/document-types">
                 <Button className="flex items-center gap-2">
                   <FileText className="w-4 h-4" />
                   Ver Tipos

--- a/src/components/ButtonNavigation.tsx
+++ b/src/components/ButtonNavigation.tsx
@@ -10,6 +10,7 @@ function ButtonNavigation() {
     { href: '/', name: 'Inicio' },
     { href: '/admin', name: 'Admin' },
     { href: '/admin/usuarios', name: 'Usuarios' },
+    { href: '/admin/document-types', name: 'Documentales' },
   ];
 
   return (

--- a/src/components/ui/DeleteDialog.tsx
+++ b/src/components/ui/DeleteDialog.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { AlertTriangle, Loader2 } from 'lucide-react';
+
+interface DeleteDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => Promise<void> | void;
+  title?: string;
+  description?: string;
+  itemName?: string;
+  loading?: boolean;
+  disabled?: boolean;
+  disabledReason?: string;
+}
+
+export default function DeleteDialog({
+  open,
+  onClose,
+  onConfirm,
+  title = "Confirmar eliminación",
+  description,
+  itemName,
+  loading = false,
+  disabled = false,
+  disabledReason
+}: DeleteDialogProps) {
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleConfirm = async () => {
+    try {
+      setIsDeleting(true);
+      await onConfirm();
+      onClose();
+    } catch (error) {
+      // Error handling is done in the parent component
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!isDeleting && !loading) {
+      onClose();
+    }
+  };
+
+  const finalDescription = description || 
+    `¿Está seguro de que desea eliminar ${itemName ? `"${itemName}"` : 'este elemento'}?`;
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-3">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            {title}
+          </DialogTitle>
+        </DialogHeader>
+        
+        <div className="py-4">
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            {finalDescription}
+          </p>
+          
+          {disabled && disabledReason && (
+            <div className="mt-4 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-md">
+              <p className="text-sm text-amber-800 dark:text-amber-200">
+                <strong>No se puede eliminar:</strong> {disabledReason}
+              </p>
+            </div>
+          )}
+          
+          {!disabled && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-3">
+              Esta acción no se puede deshacer.
+            </p>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-3">
+          <Button 
+            variant="outline" 
+            onClick={handleClose}
+            disabled={isDeleting || loading}
+            className="transition-all duration-200 hover:scale-105 disabled:hover:scale-100"
+          >
+            {disabled ? 'Cerrar' : 'Cancelar'}
+          </Button>
+          {!disabled && (
+            <Button 
+              variant="destructive"
+              onClick={handleConfirm}
+              disabled={isDeleting || loading}
+              className="transition-all duration-200 hover:scale-105 disabled:hover:scale-100"
+            >
+              {(isDeleting || loading) && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+              Eliminar
+            </Button>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
# Document Types Management & Reusable Components

## Summary
Implements delete functionality for document types with reusable confirmation dialog and improved user experience.

## Features
- **Delete Document Types**: Confirmation dialog with validation
- **Reusable DeleteDialog**: Generic delete confirmation component
- **Smart Validation**: Prevents deletion of types in use

## Components Created
- `DeleteDialog` - Reusable delete confirmation with validation support

## API Endpoints
- `DELETE /api/admin/document-types/[id]` - Delete with validation

## Database
```sql
-- New tables
document_type (id, name, description, timestamps)
document (id, title, documentTypeId, createdById, timestamps)
```

## Migration Required
```bash
pnpm db:migrate
```