### PR TITLE
feat(admin): implement edit document type functionality

### DIFF
--- a/src/app/admin/document-types/page.tsx
+++ b/src/app/admin/document-types/page.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { Plus, FileText, Edit, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import CreateDocumentTypeForm from '@/components/admin/CreateDocumentTypeForm';
+import EditDocumentTypeForm from '@/components/admin/EditDocumentTypeForm';
 import DataTable, { Column, Pagination } from '@/components/ui/DataTable';
 import DeleteDialog from '@/components/ui/DeleteDialog';
 
@@ -31,6 +32,8 @@ export default function TiposDocumentalesPage() {
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
   const [showCreateForm, setShowCreateForm] = useState(false);
+  const [showEditForm, setShowEditForm] = useState(false);
+  const [itemToEdit, setItemToEdit] = useState<DocumentType | null>(null);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [itemToDelete, setItemToDelete] = useState<DocumentType | null>(null);
   const [pagination, setPagination] = useState<Pagination>({
@@ -106,8 +109,6 @@ export default function TiposDocumentalesPage() {
       
       const data: DocumentTypesResponse = await response.json();
       if (data.documentTypes && data.pagination) {
-        console.log('Fetched document types:', data.documentTypes);
-        console.log('Pagination info:', data.pagination);
         
         setDocumentTypes(data.documentTypes);
         setPagination(data.pagination);
@@ -190,6 +191,26 @@ export default function TiposDocumentalesPage() {
     setItemToDelete(null);
   };
 
+  const handleEditClick = (item: DocumentType) => {
+    if (!item.id || item.id.trim() === '') {
+      toast.error('Error: ID del tipo documental no válido. Intenta refrescar la página.');
+      return;
+    }
+    setItemToEdit(item);
+    setShowEditForm(true);
+  };
+
+  const handleEditCancel = () => {
+    setShowEditForm(false);
+    setItemToEdit(null);
+  };
+
+  const handleDocumentTypeUpdated = () => {
+    setShowEditForm(false);
+    setItemToEdit(null);
+    fetchDocumentTypes();
+  };
+
   const handleDocumentTypeCreated = () => {
     setShowCreateForm(false);
     fetchDocumentTypes();
@@ -227,6 +248,7 @@ export default function TiposDocumentalesPage() {
         size="sm"
         className="h-8 w-8 p-0 transition-all duration-200 hover:scale-105 hover:bg-blue-50 hover:text-blue-700 dark:hover:bg-blue-900/20 dark:hover:text-blue-300"
         title="Editar"
+        onClick={() => handleEditClick(item)}
       >
         <Edit className="h-4 w-4 transition-transform duration-200" />
       </Button>
@@ -293,6 +315,14 @@ export default function TiposDocumentalesPage() {
         open={showCreateForm}
         onClose={() => setShowCreateForm(false)}
         onDocumentTypeCreated={handleDocumentTypeCreated}
+      />
+
+      {/* Edit Document Type Form */}
+      <EditDocumentTypeForm
+        open={showEditForm}
+        onClose={handleEditCancel}
+        onDocumentTypeUpdated={handleDocumentTypeUpdated}
+        documentType={itemToEdit}
       />
 
       {/* Delete Confirmation Dialog */}

--- a/src/components/admin/EditDocumentTypeForm.tsx
+++ b/src/components/admin/EditDocumentTypeForm.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { toast } from 'sonner';
+import { FileText } from 'lucide-react';
+import FormDialog from '@/components/ui/FormDialog';
+
+interface DocumentType {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+interface EditDocumentTypeFormProps {
+  open: boolean;
+  onClose: () => void;
+  onDocumentTypeUpdated: () => void;
+  documentType: DocumentType | null;
+}
+
+export default function EditDocumentTypeForm({ 
+  open, 
+  onClose, 
+  onDocumentTypeUpdated,
+  documentType
+}: EditDocumentTypeFormProps) {
+  const [loading, setLoading] = useState(false);
+  const [formData, setFormData] = useState({
+    name: '',
+    description: '',
+  });
+
+  // Pre-populate form when documentType changes
+  useEffect(() => {
+    if (documentType) {
+      setFormData({
+        name: documentType.name,
+        description: documentType.description || '',
+      });
+    }
+  }, [documentType]);
+
+  const handleInputChange = (field: string, value: string) => {
+    setFormData(prev => ({
+      ...prev,
+      [field]: value
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!formData.name.trim()) {
+      toast.error('El nombre del tipo documental es requerido');
+      return;
+    }
+
+    if (!documentType || !documentType.id) {
+      toast.error('No se pudo cargar la información del tipo documental');
+      return;
+    }
+
+    try {
+      setLoading(true);
+
+      const response = await fetch(`/api/admin/document-types/${documentType.id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: formData.name.trim(),
+          description: formData.description.trim() || null,
+        }),
+      });
+
+      if (!response.ok) {
+        let errorMessage = 'Error al actualizar tipo documental';
+        try {
+          const result = await response.json();
+          errorMessage = result.error || errorMessage;
+        } catch (e) {
+          // Error parsing failed, use default message
+        }
+        toast.error(errorMessage);
+        return;
+      }
+
+      // Try to parse success response, but don't fail if it's empty
+      try {
+        await response.json();
+      } catch (e) {
+        // No JSON response body, but request was successful
+      }
+
+      onDocumentTypeUpdated();
+      onClose();
+      toast.success('Tipo documental actualizado exitosamente');
+    } catch (error) {
+      console.error('Error updating document type:', error);
+      toast.error('Error al actualizar tipo documental');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!loading) {
+      // Reset to original values on close
+      if (documentType) {
+        setFormData({
+          name: documentType.name,
+          description: documentType.description || '',
+        });
+      }
+      onClose();
+    }
+  };
+
+  const canSubmit = formData.name.trim().length > 0;
+
+  return (
+    <FormDialog
+      open={open}
+      onClose={handleClose}
+      title="Editar Tipo Documental"
+      description="Modifica los datos del tipo documental. El nombre debe ser único y no puede estar vacío."
+      onSubmit={handleSubmit}
+      loading={loading}
+      submitText="Guardar Cambios"
+      canSubmit={canSubmit}
+    >
+      <div className="space-y-2">
+        <Label htmlFor="editDocumentTypeName">Nombre de Tipo Documental *</Label>
+        <div className="relative">
+          <FileText className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+          <Input
+            id="editDocumentTypeName"
+            type="text"
+            value={formData.name}
+            onChange={(e) => handleInputChange('name', e.target.value)}
+            placeholder="Ingresa el nombre del tipo documental"
+            className="pl-10"
+            required
+            disabled={loading}
+            maxLength={100}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="editDocumentTypeDescription">Descripción (Opcional)</Label>
+        <Input
+          id="editDocumentTypeDescription"
+          type="text"
+          value={formData.description}
+          onChange={(e) => handleInputChange('description', e.target.value)}
+          placeholder="Descripción del tipo documental"
+          disabled={loading}
+          maxLength={255}
+        />
+        <p className="text-xs text-gray-500">Ayuda a identificar este tipo documental</p>
+      </div>
+    </FormDialog>
+  );
+}

--- a/src/components/ui/FormDialog.tsx
+++ b/src/components/ui/FormDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ReactNode } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Loader2 } from 'lucide-react';
 
@@ -41,13 +41,12 @@ export default function FormDialog({
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
+          {description && (
+            <DialogDescription>
+              {description}
+            </DialogDescription>
+          )}
         </DialogHeader>
-        
-        {description && (
-          <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-            {description}
-          </p>
-        )}
         
         <form onSubmit={onSubmit} className="space-y-4">
           {children}


### PR DESCRIPTION
# Document Types Management & Reusable Components

## Summary
Implements edit functionality for document types with form validation and improved user experience using reusable components.

## Features
- **Edit Document Types**: Modal form with pre-populated data
- **Form Validation**: Name required and duplicate checking
- **Reusable FormDialog**: Enhanced with proper accessibility
- **Error Handling**: Comprehensive validation and user feedback

## Components Created
- `EditDocumentTypeForm` - Edit form using reusable FormDialog component
- Enhanced `FormDialog` - Fixed accessibility warnings with proper DialogDescription

## API Endpoints
- `PUT /api/admin/document-types/[id]` - Update with validation

## Database
```sql
-- New tables
document_type (id, name, description, timestamps)
document (id, title, documentTypeId, createdById, timestamps)
```

## Migration Required
```bash
pnpm db:migrate
```